### PR TITLE
fix: Update iam policy document

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -37,6 +37,19 @@ data "aws_iam_policy_document" "efs_csi_driver" {
       values   = ["true"]
     }
   }
+
+  statement {
+    actions = [
+      "elasticfilesystem:TagResource"
+    ]
+    resources = ["*"]
+    effect    = "Allow"
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "efs_csi_driver" {


### PR DESCRIPTION
We have found that when using the permissions currently in the efs_csi_driver that the pods are unable to mount the EFS filesystem. Adding the permissions listed in this PR allowed the access to function successfully.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [X] Any dependent changes have been merged and published in downstream modules.

## Further comments

A sample error message was

```
Unauthorized to perform operation DescribeAvailabilityZones.
```